### PR TITLE
📦 chore(autopr.yml): add autopr workflow file

### DIFF
--- a/.github/workflows/autopr.yml
+++ b/.github/workflows/autopr.yml
@@ -1,0 +1,45 @@
+on:
+  push:
+    branches:
+      - main
+  issues:
+    types: [labeled]
+  issue_comment:
+    types: [created]
+  pull_request_target:
+    types: [labeled]
+
+permissions:
+  contents: write
+  issues: write
+  pull-requests: write
+
+jobs:
+  autopr:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Install jq
+      run: sudo apt-get install jq
+    - name: Check if label was added by a collaborator
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        is_collaborator=$(curl -s -H "Authorization: token $GITHUB_TOKEN" -H "Accept: application/vnd.github+json" \
+          "https://api.github.com/repos/${{ github.repository }}/collaborators/${{ github.event.sender.login }}" | jq -r '.message')
+
+        if [ "$is_collaborator" == "Not Found" ]; then
+          echo "Label not added by a collaborator. Skipping action."
+          exit 78
+        fi
+    - name: Checkout
+      uses: actions/checkout@v2
+      with:
+        ref: main
+        fetch-depth: 1
+    - name: AutoPR
+      uses: irgolic/AutoPR@main
+      env:
+        OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        base_branch: main


### PR DESCRIPTION
This commit adds the `.github/workflows/autopr.yml` file, which contains the configuration for the AutoPR workflow. The AutoPR workflow is triggered on push to the `main` branch, when an issue is labeled, when an issue comment is created, or when a pull request is labeled. The workflow checks if the label was added by a collaborator and skips the action if it wasn't. It then checks out the `main` branch and runs the AutoPR action, which automatically creates a pull request. The action requires the `OPENAI_API_KEY` and `GITHUB_TOKEN` secrets to be set.